### PR TITLE
Fix pagination with offsets

### DIFF
--- a/crossref/restful.py
+++ b/crossref/restful.py
@@ -364,7 +364,7 @@ class Endpoint:
                 for item in result["message"]["items"]:
                     yield item
 
-                request_params["offset"] += LIMIT + 1
+                request_params["offset"] += LIMIT
 
                 if request_params["offset"] >= MAXOFFSET:
                     raise MaxOffsetError("Offset exceded the max offset of %d", MAXOFFSET)


### PR DESCRIPTION
As per the [documentation](https://api.crossref.org/swagger-ui/index.html#/Works/get_works), with offset-pagination offsets should be increased by page size. With the existing extra 1 addition, some records are being missed.