### PR TITLE
fix:timeout not working as intended by user.

### DIFF
--- a/crossref/restful.py
+++ b/crossref/restful.py
@@ -924,7 +924,8 @@ class Works(Endpoint):
                 )
             request_params["query.%s" % field.replace("_", "-")] = value
 
-        return self.__class__(request_url, request_params, context, self.etiquette)
+        return self.__class__(request_url=request_url, request_params=request_params, context=context,
+                              etiquette=self.etiquette, timeout=self.timeout)
 
     def sample(self, sample_size=20):
         """

--- a/crossref/restful.py
+++ b/crossref/restful.py
@@ -924,8 +924,11 @@ class Works(Endpoint):
                 )
             request_params["query.%s" % field.replace("_", "-")] = value
 
-        return self.__class__(request_url=request_url, request_params=request_params, context=context,
-                              etiquette=self.etiquette, timeout=self.timeout)
+        return self.__class__(request_url=request_url,
+                              request_params=request_params,
+                              context=context,
+                              etiquette=self.etiquette,
+                              timeout=self.timeout)
 
     def sample(self, sample_size=20):
         """


### PR DESCRIPTION
**Issue:**
In case of `works.query` timeout was not working as expected.

**Way to replicate the issue:**
```
from crossref.restful import Works
title = "Show, Tell and Summarize: Dense Video Captioning Using Visual Cue Aided Sentence Summarization"
author = "Zhiwang  Zhang"
works = Works(timeout=(1,1)) # connect timeout, read timeout
w1 = works.query(bibliographic=title, author=author).sort("relevance")
for record in w1:
    print(record)
```

Above code should timeout after 1 second.


**Changes made:**
- [x] Make request call in `query` method consistent with other methods. 
