### PR TITLE
return instead of StopIteration (PEP 479)

### DIFF
--- a/crossref/restful.py
+++ b/crossref/restful.py
@@ -306,7 +306,7 @@ class Endpoint:
             )
 
             if result.status_code == 404:
-                raise StopIteration()
+                return
 
             result = result.json()
 
@@ -329,7 +329,7 @@ class Endpoint:
                 )
 
                 if result.status_code == 404:
-                    raise StopIteration()
+                    return
 
                 result = result.json()
 
@@ -354,7 +354,7 @@ class Endpoint:
                 )
 
                 if result.status_code == 404:
-                    raise StopIteration()
+                    return
 
                 result = result.json()
 
@@ -1580,7 +1580,7 @@ class Types(Endpoint):
         )
 
         if result.status_code == 404:
-            raise StopIteration()
+            return
 
         result = result.json()
 


### PR DESCRIPTION
The proposed changes are based on [PEP 479](https://peps.python.org/pep-0479/), which introduces changes to the handling of StopIteration in generators.

Returns are proposed as the proper way to terminate generators. StopIterations are replaced by RuntimeErrors, as in the following error trace: 

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/crossref/restful.py", line 290, in __iter__
    raise StopIteration()
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/gerit/.local/bin/colrev", line 8, in <module>
    sys.exit(main())
  File "/home/gerit/.local/lib/python3.8/site-packages/click/core.py", line 828, in __call__
    return self.main(*args, **kwargs)
  File "/home/gerit/.local/lib/python3.8/site-packages/click/core.py", line 781, in main
    rv = self.invoke(ctx)
  File "/home/gerit/.local/lib/python3.8/site-packages/click/core.py", line 1227, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/gerit/.local/lib/python3.8/site-packages/click/core.py", line 1046, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/gerit/.local/lib/python3.8/site-packages/click/core.py", line 590, in invoke
    return callback(*args, **kwargs)
  File "/home/gerit/.local/lib/python3.8/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/gerit/ownCloud/data/AI Research/Literature Reviews/LRTemplate/colrev/colrev/ui_cli/cli.py", line 401, in search
    colrev.ui_cli.add_packages.add_search_source(
  File "/home/gerit/ownCloud/data/AI Research/Literature Reviews/LRTemplate/colrev/colrev/ui_cli/add_packages.py", line 310, in add_search_source
    search_operation.add_source(add_source=add_source)
  File "/home/gerit/ownCloud/data/AI Research/Literature Reviews/LRTemplate/colrev/colrev/ops/search.py", line 77, in add_source
    self.main(selection_str=str(add_source.filename), rerun=False, skip_commit=True)
  File "/home/gerit/ownCloud/data/AI Research/Literature Reviews/LRTemplate/colrev/colrev/ops/search.py", line 350, in main
    endpoint.run_search(search_operation=self, rerun=rerun)  # type: ignore
  File "/home/gerit/ownCloud/data/AI Research/Literature Reviews/LRTemplate/colrev/colrev/ops/built_in/search_sources/crossref.py", line 797, in run_search
    self.__run_parameter_search(
  File "/home/gerit/ownCloud/data/AI Research/Literature Reviews/LRTemplate/colrev/colrev/ops/built_in/search_sources/crossref.py", line 688, in __run_parameter_search
    for record_dict in self.__get_crossref_query_return():
  File "/home/gerit/ownCloud/data/AI Research/Literature Reviews/LRTemplate/colrev/colrev/ops/built_in/search_sources/crossref.py", line 594, in __get_crossref_query_return
    yield from self.__journal_query(journal_issn=journal_issn)
  File "/home/gerit/ownCloud/data/AI Research/Literature Reviews/LRTemplate/colrev/colrev/ops/built_in/search_sources/crossref.py", line 179, in __journal_query
    for item in crossref_query_return:
RuntimeError: generator raised StopIteration
```