### PR TITLE
Add ability to specify request parameters to "all" function.

### DIFF
--- a/crossref/restful.py
+++ b/crossref/restful.py
@@ -274,10 +274,12 @@ class Endpoint:
 
         return req.url
 
-    def all(self):
+    def all(self, request_params: dict = None):
         context = str(self.context)
         request_url = build_url_endpoint(self.ENDPOINT, context)
-        request_params = {}
+
+        if request_params is None:
+            request_params = {}
 
         return iter(
             self.__class__(


### PR DESCRIPTION
At present, the request parameters are always set to an empty dictionary. However, the Crossref Labs API, which provides additional experimental functionality, has various options that are controlled by querystring parameters. It is, therefore, useful to have a way to set this as it allows for the usage of these aternative API endpoints.

An example usage might be:

    members = Members(
                etiquette=my_etiquette,
            )
    crossref.restful.API = "api.labs.crossref.org"
    members.ENDPOINT = "members"

    members.all(request_params={"rows":"all", "simple":"True"})

More about the Crossref Labs API can be found at https://api.labs.crossref.org and https://api.labs.crossref.org/docs.

Disclaimer: the author of this commit, Martin Paul Eve, works for Crossref. This does not imply correctness or safety of the submitted code, which is subject to the disclaimers of the LICENSE file.